### PR TITLE
Update Makefile - VCTK file isn't on the old URL anymore

### DIFF
--- a/data/vctk/Makefile
+++ b/data/vctk/Makefile
@@ -1,4 +1,4 @@
-URL:=http://homepages.inf.ed.ac.uk/jyamagis/release/VCTK-Corpus.tar.gz
+URL:=http://www.udialogue.org/download/VCTK-Corpus.tar.gz
 
 # ----------------------------------------------------------------------------
 # load corpus


### PR DESCRIPTION
VCTK data is no longer hosted at the location stored in the original Makefile. Found the archive elsewhere, from what appears to be the original host instead of a mirror.