### PR TITLE
Replace hard coded path separator in regex

### DIFF
--- a/data/vctk/prep_vctk.py
+++ b/data/vctk/prep_vctk.py
@@ -87,7 +87,8 @@ def add_data(h5_file, inputfiles, args, save_examples=False):
   for j, file_path in enumerate(file_list):
     if j % 10 == 0: print('%d/%d' % (j, num_files))
 
-    ID = int(re.search('p\d\d\d/', file_path).group(0)[1:-1])
+    directory_id_matches = re.search(fr'p(\d{{3}})\{os.path.sep}', file_path)
+    ID = int(directory_id_matches.group(1))
 
     # load audio file
     x, fs = librosa.load(file_path, sr=args.sr)


### PR DESCRIPTION
The forward slash is unix specific and crashes the script on windows systems.
Also replaced manual extraction of the directory number.